### PR TITLE
Drop domain information from AD users and groups

### DIFF
--- a/scripts/client.sh
+++ b/scripts/client.sh
@@ -47,3 +47,10 @@ while ! realm discover "$domain" ; do
 done
 
 echo "$1" | realm join --membership-software=adcli "$domain"
+
+sed -i \
+    -e '/^use_fully_qualified_names\>/s/True/False/' \
+    -e '/^fallback_homedir\>/s/@.*$//' \
+    /etc/sssd/sssd.conf
+
+systemctl restart sssd.service


### PR DESCRIPTION
Disable `use_fully_qualified_names` and remove domain from
`fallback_homedir` in sssd.conf.

Fixes #4.